### PR TITLE
hotfix/jdk-version-fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-# Etapa 1: Compilar con Java 24
-FROM maven:3.9.6-eclipse-temurin-24 AS builder
+# Etapa 1: Compilación
+FROM maven:3.9.6-eclipse-temurin-21 AS builder
 WORKDIR /app
 COPY . .
 RUN mvn clean package -DskipTests
 
-# Etapa 2: Imagen final con Java 24
-FROM eclipse-temurin:24-jdk-alpine
+# Etapa 2: Imagen final
+FROM eclipse-temurin:21-jdk-alpine
 WORKDIR /app
 COPY --from=builder /app/target/*.jar app.jar
 EXPOSE 8080

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 		<url/>
 	</scm>
 	<properties>
-		<java.version>24</java.version>
+		<java.version>21</java.version>
 	</properties>
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
### Summary
This hotfix updates the JDK version to ensure compatibility across the build system and Docker container.

### Changes
- Updated `pom.xml` to use the correct JDK version for project compilation.
- Adjusted `Dockerfile` to match the updated JDK version for consistent runtime behavior.

### Rationale
The previous mismatch between the local JDK and Docker image caused build and deployment inconsistencies. This fix ensures alignment across environments.